### PR TITLE
add AWSCore 0.1 lower bound to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,5 @@
 julia 0.5
-AWSCore
+AWSCore 0.1
 AWSIAM
+SymDict
+Retry


### PR DESCRIPTION
and direct dependencies on SymDict, Retry which are imported
but not directly depended on (assumed to be present as transitive deps)